### PR TITLE
Fix internal urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Bonjour et bienvenue sur le dépôt de Data.gouv.fr
 Ce dépôt ne contient pas de code mais permet de centraliser la connaissance sur Data.gouv.fr.
 
 Aujourd'hui, vous pouvez:
-- [rapporter un bug](issues/new)
-- [exprimer un souhait d'évolution ou de nouvelle fonctionnalité](issues/new)
-- [en savoir plus sur le fonctionnement interne de Data.gouv.fr et de son équipe](wiki)
+- [rapporter un bug](https://github.com/etalab/data.gouv.fr/issues/new)
+- [exprimer un souhait d'évolution ou de nouvelle fonctionnalité](https://github.com/etalab/data.gouv.fr/issues/new)
+- [en savoir plus sur le fonctionnement interne de Data.gouv.fr et de son équipe](https://github.com/etalab/data.gouv.fr/wiki)


### PR DESCRIPTION
For some reason, relatives urls like `issue/new` end as `https://github.com/etalab/data.gouv.fr/blob/master/issues/new` which does not work (404). Using absolute urls instead (`https://github.com/etalab/data.gouv.fr/issues/new`)