### PR TITLE
Ajout des CGU

### DIFF
--- a/CGU.md
+++ b/CGU.md
@@ -1,0 +1,236 @@
+# Conditions d'utilisation
+
+[Data.gouv.fr][] est la plateforme ouverte des données publiques du Gouvernement français.
+
+Elle est éditée et développée par la Mission Etalab (ci-après, Etalab) de la Direction interministérielle du numérique et du système d'information et de communication de l'Etat (DINSIC) au sein du Secrétariat général pour la modernisation de l'action publique (SGMAP).
+
+Toute utilisation de la plateforme [data.gouv.fr][] (ci-après, la Plateforme) est subordonnée au respect des présentes conditions générales d'utilisation (CGU).
+
+Est défini comme :
+
+**API (web)** : interface web structurée permettant d'interagir automatiquement avec un système d'information, qui inclut généralement la récupération de données à la demande ;
+
+**Autorités administratives** : toute personne publique ou privée chargée d'une mission de service public (article L. 300-2 du code des relations du public et de l'administration (CRPA)) ;
+
+**Contributeur** : toute personne inscrite sur la plateforme, notamment, afin de mettre à disposition un Jeu de données dont la publication présente un intérêt public, telles que celles qui :
+
+- assurent une meilleure information des citoyens, notamment en matière économique, sociale, sanitaire ou environnementale,
+- permettent une conduite plus efficace de politiques publiques,
+- bénéficient au développement économique,
+- concourent à la recherche scientifique et à l'investigation journalistique,
+
+ou dans le but de discuter ou de diffuser une réutilisation ;
+
+**Informations publiques** : informationsfigurant dans des documents produits ou reçus par des Autorités administratives, communicables à toute personne ou ayant fait l'objet d'une diffusion publique conforme aux articles [L. 312-1 à L. 312-1-2](https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000031366350&amp;idArticle=LEGIARTI000031367739&amp;dateTexte=&amp;categorieLien=cid) du CRPA) et sur lesquelles des tiers ne détiennent pas de droit de propriété intellectuelle(articles L. 321-1 et suivants) ;
+
+**Jeu de données** : ensemble cohérent de ressources ou d'informations (fichiers de données, fichiers d'explications, API, lien...) et de métadonnées (présentation, date de publication, mots-clefs, couverture géographique/temporelle...), sur un thème donné ;
+
+**Réutilisation** : utilisation par toute personne (Réutilisateur) des données publiées à des fins autres que celles pour lesquelles elles ont été produites ou reçues;
+
+**Utilisateur** : toute personne accédant à la Plateforme afin de consulter ou télécharger des contenus ou d'y contribuer.
+
+## Objet
+
+La Plateforme permet :
+
+- la publication par les Autorités administratives d'Informations publiques et par tout Contributeur de données dont la publication présente un intérêt public,
+- la consultation ou le téléchargement de ces données par tout Utilisateur,
+- une discussion autour des données, ainsi que la diffusion de Jeux de données enrichis ou de Réutilisations.
+
+## Fonctionnalités
+
+L'utilisation de la Plateforme est libre et gratuite.
+
+### Consultation et téléchargement des données
+
+La consultation des contenus mis à disposition ou leur téléchargement ne nécessite aucune d'inscription préalable.
+
+### Inscription sur la plateforme et fonctionnalités liées
+
+Toute personne, morale ou physique, publique ou privée, peut contribuer à la Plateforme, en publiant des Jeux de données, des Réutilisations de ceux-ci, en publiant des textes, ressources et commentaires relatifs aux Jeux de données.
+
+Pour ce faire, l'Utilisateur s'inscrit sur la Plateforme. Cette inscription est propre  à sa personne et non à l'entité ou personne morale qu'il représente.
+
+En s'inscrivant, l'Utilisateur crée un profil sur la Plateforme. Pour plus de précisions, voir la rubrique Vie privée.
+
+Dès validation de son inscription, les différentes fonctionnalités sont disponibles.
+
+Le Contributeur dispose de fonctionnalités « communautaires », notamment :
+
+- créer ou rejoindre une organisation (voir rubrique dédiée),
+- publier un Jeu de données sous la forme d'un fichier téléchargeable, d'un lien ou d'une API,
+- publier des ressources additionnelles associées à un Jeu de données proposé par un autre Contributeur, par exemple, le même Jeu de données enrichi,
+- publier une Réutilisation, c'est-à-dire un lien vers celle-ci ainsi qu'une présentation,
+- publier un commentaire dans une discussion sur un Jeu de données, par exemple, pour signaler des anomalies dans une ressource ou un Jeu de données.
+
+Il dispose également d'autres fonctionnalités telles que le suivi d'un Jeu de données ou d'une organisation ; le partage et l'intégration d'un Jeu de données ou d'une ressource directement sur un autre site.
+
+Enfin, il peut participer au contrôle de la qualité de la Plateforme en signalant les contenus n'ayant pas vocation à y figurer (illicites ou contraires aux CGU). Il peut également contacter directement le Contributeur ayant publié un Jeu de données.
+
+### Organisations et fonctionnalités liées
+
+Les Contributeurs peuvent créer ou rejoindre des organisations. Il s'agit le plus souvent de personnes morales (autorités administratives, associations, entreprises) mais également de groupes informels. Chaque organisation a un espace dédié animé par un ou plusieurs administrateurs.
+
+Les organisations peuvent :
+
+- publier des Jeux de données,
+- publier des ressources additionnelles,
+- publier des Réutilisations.
+
+Elles ne peuvent pas commenter dans une discussion. Seuls les Contributeurs personnes physiques peuvent le faire.
+
+Etalab propose deux types de certifications des organisations :
+
+- la certification de service public : elle identifie les Autorités administratives,
+- la certification d'authenticité de l'organisation.
+
+Pour être certifiée, l'organisation en fait la demande par courriel à : <certification@data.gouv.fr>.
+
+Cette certification permet notamment de bénéficier d'un meilleur classement dans les résultats du moteur de recherche de la plateforme. La certification d'une organisation n'emporte pas la certification des Jeux de données qu'elle met à disposition.
+
+Etalab se réserve la possibilité de révoquer une certification pour tout manquement aux présentes conditions d'utilisation.
+
+## Code de conduite et responsabilités des Contributeurs
+
+### Publication d'un Jeu de données ou d'une Réutilisation
+
+#### Règles générales
+
+La Plateforme diffuse des Informations publiques et les données d'intérêt public publiées par les Contributeurs qui peuvent être mises à disposition en téléchargement, par le biais d'une API ou référencées par un lien.
+
+La Plateforme n'a pas vocation à diffuser des données publicitaires, de promotion d'intérêts privés, contrevenant à l'ordre public ou, plus généralement, illicite. Etalab est susceptible, le cas échéant, sans préavis, de supprimer ou rendre impossible l'accès à de telles données.
+
+Etalab encourage les Contributeurs à fiabiliser et documenter les données qu'ils publient. Les Autorités administratives actualisent les bases de données qu'elles publient, conformément à l'article L. 312-1-1 du CRPA.
+
+Les Contributeurs publiant un Jeu de donnée sont invités à animer la page dédiée ; à cette fin, ils sont notifiés par courriel de chaque nouvelle contribution sur cette page (discussion, commentaire, signalement, suivi, ajout d'une ressource communautaire ou d'une Réutilisation).
+
+Les Contributeurs sont seuls responsables des données, métadonnées ou contenus qu'ils publient sur la Plateforme.
+
+#### Données à caractère personnel
+
+Les Jeux de données contenant des données à caractère personnel, c'est-à-dire des données, y compris non nominatives, permettant la ré-identification de personnes physiques, ne peuvent pas être diffusés par la Plateforme sauf si les personnes concernées ont donné leur accord ou si une disposition législative ou le décret prévu à l'article L. 312-1-2 du CRPA le permet.
+
+Le Contributeur publiant le Jeu de données est responsable des jeux de données qu'il publie sur la Plateforme et s'assure que cette publication est conforme à la législation en vigueur. Il prend toute mesure nécessaire à cette fin et Etalab l'encourage à mentionner la présence de données à caractère personnel dans la documentation accompagnant le Jeu de données et préciser, lorsqu'elles existent, les restrictions juridiques à la Réutilisation.
+
+Le Réutilisateur de telles données doit se conformer à la législation relative à la protection des données à caractère personnel en vigueur dans son territoire de résidence et respecter les stipulations pertinentes de la licence attachée à ces données.
+
+#### Données couvertes par des droits de propriété intellectuelle
+
+Lorsque l'Autorité administrative ou le Contributeur publie un jeu de données comprenant des droits de propriété intellectuelle qui font obstacle à la Réutilisation, il mentionne leur présence dans la documentation accompagnant le Jeu de données. Il indique l'identité de la personne physique ou morale titulaire de ces droits ou, si celle-ci n'est pas connue, l'identité de la personne auprès de laquelle l'information en cause a été obtenue.
+
+#### Licences
+
+Les Autorités administratives publient leurs Jeux de données sous Licence Ouverte ou ODbL, sauf homologation spécifique de licence (voir : <https://www.data.gouv.fr/licences>).
+
+Les autres Contributeurs publient leurs Jeux de données sous Licence Ouverte ou l'une des licences conformes à l_'open definition_ (voir : <http://opendefinition.org/licenses/>).
+
+Les ressources des Jeux de données sont soumises à la licence choisie par le Contributeur publiant les données et affichée sur la page de chaque Jeu de données.
+
+### Publication de commentaire
+
+Les discussions ont vocation à porter sur le Jeu de données publié. Les Contributeurs ne publient pas de messages de nature publicitaire ou promotionnelle, à caractère raciste ou diffamatoire, grossier ou injurieux, agressif ou violent ou de façon générale qui contreviendrait aux bonnes mœurs, l'ordre public ou aux dispositions légales en vigueur.
+
+Les Contributeurs publiant un commentaire dans une discussion cèdent leurs droits de propriété intellectuelle sur ceux-ci de façon non exclusive, à titre gracieux, pour le monde entier, pour toute la durée de ces droits.
+
+### Utilisation de contact <info@data.gouv.fr>
+
+L'adresse de contact permet de contacter Etalab et n'a pas pour objet de recevoir des demandes relatives à la situation individuelle d'un usager dans ses relations avec une Autorité administrative. Elle n'est pas non plus un moyen direct de contacter un Contributeur. Les Contributeurs peuvent être contactés via le formulaire de contact sur la page du Jeu de données concerné.
+
+## Engagements et responsabilités d'Etalab
+
+### Qualité de service et facilités offertes
+
+Etalab s'efforce de garantir la disponibilité de la plateforme 99,5 % du temps mensuel, apprécié au terme de chaque mois.
+
+Etalab propose, au choix du Contributeur, la publication de Jeux de données, via l'interface web de la plateforme, par l'intermédiaire d'une interface de programmation (API web) ou par le « moissonnage » de la plateforme du Contributeur (pour les sites compatibles).
+
+Etalab donne accès, au choix de l'utilisateur, aux Jeux de données via l'interface web ou par l'intermédiaire d'une API web.
+
+Etalab s'engage à prendre toutes précautions utiles pour préserver l'intégrité des Jeux de données mis à disposition, et notamment empêcher qu'ils soient déformés ou endommagés.
+
+À la seule fin de garantir une meilleure information de l'Utilisateur, à travers un meilleur référencement, et sans jamais en dénaturer le sens, Etalab se réserve la possibilité de modifier les métadonnées associées à un Jeu de données.
+
+Etalab se réserve également la liberté de faire évoluer, de modifier ou de suspendre, sans préavis, la Plateforme pour des raisons de maintenance ou pour tout autre motif jugé nécessaire. L'indisponibilité de la Plateforme ne donne droit à aucune indemnité.
+
+### Responsabilités d'Etalab
+
+Etalab est responsable des contenus qu'Etalab propose afin d'animer la Plateforme.
+
+Etalab n'effectue pas de contrôle _a priori_ sur les publications des Autorités administratives ou des Contributeurs sur la Plateforme. Dès qu'Etalab a connaissance de contenus illicites, Etalab agit rapidement pour retirer ces données ou en rendre l'accès impossible. À cette fin, une procédure de signalement est mise en place sur la Plateforme. Tout Utilisateur peut signaler un contenu non conforme aux présentes conditions d'utilisation. Etalab se réserve notamment la possibilité de supprimer ou de rendre inaccessibles, sans préavis, les contributions sans lien avec l'activité de la Plateforme, publiées aux fins d'entraver le bon fonctionnement de la Plateforme, de publicité ou de promotion, de propagande ou de prosélytisme et toute contribution contrevenant aux lois et règlements en vigueur. Etalab se réserve également la possibilité de supprimer le profil d'un Contributeur et de refuser que certaines personnes aient accès à la plateforme, en cas de violation des présentes conditions d'utilisation.
+
+### Transparence sur le classement et mises en avant
+
+L'ordre de classement des Jeux de données issu du moteur de recherche de la Plateforme est issu d'un algorithme libre, dont [le code source est disponible ici](https://github.com/opendatateam/udata/tree/master/udata/search).
+
+Etalab choisit de mettre en avant certains contenus à travers les rubriques « L'Actu en données », « Jeux de données à la une » et « Meilleures Réutilisations », sur les pages d'accueil de la Plateforme et des rubriques thématiques.
+
+### Contenus proposés par Etalab
+
+Les contenus proposés par Etalab sont sous [Licence Ouverte](https://www.etalab.gouv.fr/wp-content/uploads/2017/04/ETALAB-Licence-Ouverte-v2.0.pdf), à l'exception des logos et des représentations iconographiques et photographiques qui peuvent être régis par leurs licences propres.
+
+Le code source de la plateforme est libre et disponible ici : <https://github.com/opendatateam/udata>.
+
+### Evolution des conditions d'utilisation
+
+Les termes des présentes conditions d'utilisation peuvent être amendés à tout moment, sans préavis, en fonction des modifications apportées à la Plateforme, de l'évolution de la législation ou pour tout autre motif jugé nécessaire.
+
+## Vie privée
+
+### Cookies
+
+Le site dépose des cookies de mesure d'audience (nombre de visites, pages consultées), respectant les conditions d'exemption du consentement de l'internaute définies par la recommandation « Cookies » de la Commission nationale informatique et libertés (CNIL) ; il utilise Piwik, un outil libre, paramétré pour ce faire. Cela signifie, notamment, que ces cookies ne servent qu'à la production de statistiques anonymes et ne permettent pas de suivre la navigation de l'internaute sur d'autres sites.
+
+Le site dépose également des cookies de navigation, aux fins strictement techniques, qui ne sont pas conservés.
+
+La consultation de la Plateforme n'est pas affectée lorsque les Utilisateurs utilisent des navigateurs désactivant les cookies.
+
+### Données à caractère personnel
+
+La consultation des Jeux de données (y compris leur téléchargement) ne nécessite pas de s'inscrire, ni de s'authentifier.
+
+L'inscription à la Plateforme nécessite que l'Utilisateur communique à Etalab ses prénom et nom, ainsi que son courriel. Etalab s'engage à prendre toutes les mesures nécessaires permettant de garantir la sécurité et la confidentialité du courriel de l'Utilisateur. Celui-ci n'est jamais communiqué à des tiers, en dehors des cas prévus par la loi.
+
+La page de profil du Contributeur comprend ses prénom et nom et des éléments sur son activité (les pages suivies et les jeux de données publiés). Cette page n'est pas référencée par le moteur de recherche de la Plateforme.
+
+L'historique de consultation de l'Utilisateur n'est jamais rendu public, ni communiqué à des tiers, en dehors des cas prévus par la loi.
+
+En application de la loi n° 78-17 du 6 janvier 1978 relative à l'informatique, aux fichiers et aux libertés, l'Utilisateur dispose d'un droit d'accès, de rectification et d'opposition auprès d'Etalab. Ce droit s'exerce par courriel adressé à <contact@data.gouv.fr> ou par voie postale à Mission Etalab, Tour Mirabeau 39-43 quai André-Citroën 75015 Paris.
+
+La Plateforme a été déclarée à la Commission Nationale de l'Informatique et des Libertés (CNIL) sous le numéro : eRa0876341t.
+
+## Textes de référence
+
+[Livre III du code des relations entre le public et l'administration](https://www.legifrance.gouv.fr/affichCode.do;jsessionid=2B8CFC0D49E08E4D1843153F6E476CA7.tpdila11v_2?idSectionTA=LEGISCTA000031367685&amp;cidTexte=LEGITEXT000031366350&amp;dateTexte=20170808)
+
+[Loi n° 78-17 du 6 janvier 1978 relative à l'informatique, aux fichiers et aux libertés](https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000886460)
+
+[Loi n° 2004-575 du 21 juin 2004 pour la confiance dans l'économie numérique](https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000801164)
+
+[Loi n° 2016-1321 du 7 octobre 2016 pour une République numérique](https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000033202746&amp;categorieLien=id)
+
+Les textes d'organisation d'Etalab
+
+## Mentions légales
+
+### Editeur
+
+Mission Etalab, Direction interministérielle du numérique et du système d'information et de communication de l'Etat (DINSIC), Secrétariat général pour la modernisation de l'action publique (SGMAP).
+
+### Directrice de la publication
+
+M<sup>me</sup> Laure LUCCHESI, Cheffe de la Mission Etalab, Direction interministérielle du numérique et du système d'information et de communication de l'Etat (DINSIC), Secrétariat général pour la modernisation de l'action publique (SGMAP).
+
+### Prestataire d'hébergement
+
+OVH
+
+RCS Roubaix – Tourcoing 424 761 419 00045
+
+Code APE 6202A
+
+N° TVA : FR 22 424 761 419
+
+Siège social : 2 rue Kellermann - 59100 Roubaix - France.
+
+
+[data.gouv.fr]: https://www.data.gouv.fr/

--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ Aujourd'hui, vous pouvez:
 - [rapporter un bug](https://github.com/etalab/data.gouv.fr/issues/new)
 - [exprimer un souhait d'évolution ou de nouvelle fonctionnalité](https://github.com/etalab/data.gouv.fr/issues/new)
 - [en savoir plus sur le fonctionnement interne de Data.gouv.fr et de son équipe](https://github.com/etalab/data.gouv.fr/wiki)
+
+Ce dépôt contient aussi [les conditions générales d'utilisation de Data.gouv.fr](https://github.com/etalab/data.gouv.fr/blob/master/CGU.md) sur lesquelles vous pouvez nous signaler des erreurs ou proposer des modifications


### PR DESCRIPTION
Cette PR ajoute les CGU de Data.gouv.fr en markdown.
L'objectif est de pouvoir intégrer directement ce fichier markdown sur le site data.gouv.fr afin de faciliter l’édition, la correction, la contribution... et de décorréler le contenu des CGU spécifiques de data.gouv.fr des releases d'extensions ou de thèmes qui eux sont réutilisables par d'autres sites.

